### PR TITLE
load_codeset supports .chunk_size param

### DIFF
--- a/R/codesets.R
+++ b/R/codesets.R
@@ -104,7 +104,7 @@ load_codeset <- function(name,
                          db = config('db_src'),
                          .chunk_size = 5000)
   get_argos_default()$load_codeset(name, col_types, table_name, indexes,
-                                   full_path, db)
+                                   full_path, db, .chunk_size)
 
 argos$set(
   'public', 'load_codeset',


### PR DESCRIPTION
load_codeset accept .chunk_size as a parameter and will pass down to copy_to_new